### PR TITLE
Remove any non alphanumeric char from PDF filename normalization

### DIFF
--- a/kiss-automated-pdf-linker.php
+++ b/kiss-automated-pdf-linker.php
@@ -750,7 +750,7 @@ function kapl_normalize_filename( $filename ) {
 	// Remove file extension.
 	$filename = pathinfo( $filename, PATHINFO_FILENAME );
 	// Remove common separators.
-	$filename = str_replace( ['-', '–', '_', ' '], '', $filename );
+	$filename = preg_replace( '/[^a-zA-Z0-9]/', '', $filename );
 	return $filename;
 }
 


### PR DESCRIPTION
Related to PR: https://github.com/kissplugins/automated-pdf-linker/pull/6