### PR TITLE
Add folder file viewer to admin settings

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -80,6 +80,58 @@
     margin-right: 10px;
 }
 
+.kapl-folder-viewer {
+    margin-top: 15px;
+}
+
+.kapl-folder-viewer__folder {
+    margin-bottom: 12px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    background: #fff;
+    padding: 0 12px 12px;
+}
+
+.kapl-folder-viewer__folder > summary {
+    cursor: pointer;
+    font-weight: 600;
+    margin: 0 -12px 12px;
+    padding: 12px;
+    background: #f6f7f7;
+    border-bottom: 1px solid #dcdcde;
+}
+
+.kapl-folder-viewer__file-list {
+    margin: 0;
+    padding-left: 18px;
+    list-style: disc;
+}
+
+.kapl-folder-viewer__file {
+    margin-bottom: 6px;
+}
+
+.kapl-folder-viewer__file a {
+    text-decoration: none;
+}
+
+.kapl-folder-viewer__file a:hover,
+.kapl-folder-viewer__file a:focus {
+    text-decoration: underline;
+}
+
+.kapl-folder-viewer__path {
+    display: block;
+    font-size: 12px;
+    color: #666;
+}
+
+.kapl-folder-viewer__empty {
+    margin: 0;
+    color: #666;
+    font-style: italic;
+}
+
 /* Responsive adjustments */
 @media (max-width: 782px) {
     .kapl-test-result {

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -96,6 +96,10 @@ class AdminMenu {
 
             <hr>
 
+            <?php $this->render_folder_file_listing_viewer(); ?>
+
+            <hr>
+
             <h2><?php \esc_html_e( 'System Self-Tests', 'kiss-automated-pdf-linker' ); ?></h2>
             <p><?php \esc_html_e( 'Run diagnostic tests to verify plugin functionality and catch potential issues.', 'kiss-automated-pdf-linker' ); ?></p>
 
@@ -120,13 +124,13 @@ class AdminMenu {
      */
     private function render_index_status(): void {
         $index_stats = $this->settings->get_index_builder()->get_index_stats();
-        
+
         echo '<p><em>' . \esc_html( $index_stats['message'] ) . '</em></p>';
-        
+
         if ( 'ready' === $index_stats['status'] ) {
             echo '<details>';
             echo '<summary>' . \esc_html__( 'Index Details', 'kiss-automated-pdf-linker' ) . '</summary>';
-            
+
             $validation = $this->settings->get_index_builder()->validate_index();
             if ( $validation['is_valid'] ) {
                 echo '<p style="color: green;">✓ ' . \esc_html__( 'Index is valid', 'kiss-automated-pdf-linker' ) . '</p>';
@@ -136,8 +140,84 @@ class AdminMenu {
                     echo '<p style="color: red; margin-left: 20px;">• ' . \esc_html( $error ) . '</p>';
                 }
             }
-            
+
             echo '</details>';
         }
+    }
+
+    /**
+     * Render the folder file listing viewer.
+     *
+     * @return void
+     */
+    private function render_folder_file_listing_viewer(): void {
+        $settings = $this->settings->get_settings();
+        $selected_directories = $settings['selected_directories'] ?? [];
+
+        echo '<h2>' . \esc_html__( 'Folder File Listing Viewer', 'kiss-automated-pdf-linker' ) . '</h2>';
+        echo '<p>' . \esc_html__( 'Review the PDF files that were discovered in each selected folder. Click a file name to open it in a new tab.', 'kiss-automated-pdf-linker' ) . '</p>';
+
+        if ( empty( $selected_directories ) ) {
+            echo '<p><em>' . \esc_html__( 'No folders have been selected for scanning yet. Choose folders above and rebuild the index to see their contents.', 'kiss-automated-pdf-linker' ) . '</em></p>';
+            return;
+        }
+
+        $grouped_files = $this->settings->get_index_builder()->get_index_by_directory( $selected_directories );
+
+        if ( empty( $grouped_files ) ) {
+            echo '<p><em>' . \esc_html__( 'The index does not contain any PDFs yet. Rebuild the index after selecting folders to populate this viewer.', 'kiss-automated-pdf-linker' ) . '</em></p>';
+            return;
+        }
+
+        $upload_dir_info = wp_upload_dir();
+        $base_url = trailingslashit( $upload_dir_info['baseurl'] );
+
+        echo '<div class="kapl-folder-viewer">';
+
+        foreach ( $selected_directories as $directory ) {
+            $files = $grouped_files[ $directory ] ?? [];
+
+            echo '<details class="kapl-folder-viewer__folder" open>';
+            echo '<summary>' . \esc_html( $directory ) . '/</summary>';
+
+            if ( empty( $files ) ) {
+                echo '<p class="kapl-folder-viewer__empty">' . \esc_html__( 'No PDF files found in this folder.', 'kiss-automated-pdf-linker' ) . '</p>';
+                echo '</details>';
+                continue;
+            }
+
+            echo '<ul class="kapl-folder-viewer__file-list">';
+
+            foreach ( $files as $file ) {
+                $relative_path = isset( $file['path'] ) ? (string) $file['path'] : '';
+                $file_name = isset( $file['filename'] ) ? (string) $file['filename'] : basename( $relative_path );
+
+                if ( '' === $relative_path ) {
+                    continue;
+                }
+
+                $file_url = $base_url . ltrim( $relative_path, '/' );
+                $folder_prefix = $directory . '/';
+                $display_path = $relative_path;
+
+                if ( 0 === strpos( $relative_path, $folder_prefix ) ) {
+                    $display_path = substr( $relative_path, strlen( $folder_prefix ) );
+                }
+
+                echo '<li class="kapl-folder-viewer__file">';
+                echo '<a href="' . esc_url( $file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $file_name ) . '</a>';
+
+                if ( '' !== $display_path && $display_path !== $file_name ) {
+                    echo '<span class="kapl-folder-viewer__path">' . esc_html( $display_path ) . '</span>';
+                }
+
+                echo '</li>';
+            }
+
+            echo '</ul>';
+            echo '</details>';
+        }
+
+        echo '</div>';
     }
 }

--- a/src/Services/IndexBuilder.php
+++ b/src/Services/IndexBuilder.php
@@ -217,4 +217,43 @@ class IndexBuilder {
     public function get_available_directories(): array {
         return $this->file_scanner->get_available_directories();
     }
+
+    /**
+     * Group index entries by their top-level directory.
+     *
+     * @param array $selected_directories Directories that should be included in the grouping.
+     * @return array<string, array> Array keyed by directory names containing the matching index entries.
+     */
+    public function get_index_by_directory( array $selected_directories ): array {
+        $index = $this->get_index() ?? [];
+
+        if ( empty( $selected_directories ) || empty( $index ) ) {
+            return [];
+        }
+
+        $grouped = [];
+
+        foreach ( $selected_directories as $directory ) {
+            $grouped[ $directory ] = [];
+        }
+
+        foreach ( $index as $item ) {
+            if ( ! isset( $item['path'] ) ) {
+                continue;
+            }
+
+            $relative_path = (string) $item['path'];
+            $top_level_dir = strstr( $relative_path, '/', true );
+
+            if ( false === $top_level_dir ) {
+                $top_level_dir = $relative_path;
+            }
+
+            if ( isset( $grouped[ $top_level_dir ] ) ) {
+                $grouped[ $top_level_dir ][] = $item;
+            }
+        }
+
+        return $grouped;
+    }
 }


### PR DESCRIPTION
## Summary
- add a folder file listing viewer to the admin settings page so administrators can review indexed PDFs
- extend the index builder with a helper to group indexed files by selected directory
- style the new viewer for clarity within the settings screen

## Testing
- php -l src/Admin/AdminMenu.php
- php -l src/Services/IndexBuilder.php

------
https://chatgpt.com/codex/tasks/task_b_68f278df1ab4832ea495beb8f91f5aa2