### PR TITLE
Add dark-mode styling and file metadata to folder viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the KISS Automated PDF Linker plugin will be documented i
 
 
 
+## [3.1.4] - 2025-10-17
+
+### Improved
+- High-contrast styling for the “Total files” summary in the Folder Viewer to improve legibility on dark UI.
+
+### Changed
+- DRY: The Folder Viewer now re-uses IndexBuilder::get_index_stats() to display the same total file count shown near the Rebuild Index status.
+- Admin stylesheet version bumped to 3.0.3 to refresh CSS in browsers.
+
 ## [3.1.3] - 2025-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the KISS Automated PDF Linker plugin will be documented in this file.
 
+
+
+## [3.1.3] - 2025-10-17
+
+### Added
+- Folder Viewer now shows a total file count at the top and numbers each row starting from `1.)` across all folders.
+
+### Notes
+- Added prominent code comments explaining why we detect the admin page by slug (`strpos($hook, Settings::SETTINGS_SLUG)`) to support both `tools_page_` and `settings_page_` contexts. This prevents accidental regressions.
+
+## [3.1.2] - 2025-10-17
+
+### Fixed
+- Debug assets were not loading on the Tools screen due to using the wrong admin page hook prefix. Now we detect our screen by slug and load for both `tools_page_` and `settings_page_` contexts.
+
+### Changed
+- Inline debug JS now attaches to the existing `kapl-admin-script` handle to guarantee execution.
+- Added persistent “Enable on-screen debug panel” setting under Debugging; URL `kapl_debug=1` still overrides.
+
+## [3.1.1] - 2025-10-17
+
+### Added
+- On-screen debugging for the Folder File Listing Viewer (toggle via `?kapl_debug=1`)
+- Debug panel shows whether `assets/admin.css` is enqueued, its src, version, and filemtime
+- Live measurements of table layout mode and first-row column widths/paddings
+- Visual highlights for the three columns to inspect spacing quickly
+
+### Changed
+- Bumped admin stylesheet handle version to `3.0.2` to force cache refresh
+- Plugin version bumped to `3.1.1`
+
+
 ## [3.1.0] - 2025-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to the KISS Automated PDF Linker plugin will be documented in this file.
+
+## [3.1.0] - 2025-10-17
+
+### Added
+- **File Metadata in Index**: Modified date and file size are now collected during PDF indexing
+- **Folder & Viewer Enhancements**: Display of file modification dates and file sizes in the Folder File Listing Viewer
+- **Index Migration**: Automatic detection and migration of old indexes to include new metadata fields
+- **Index Versioning**: Version tracking for the PDF index to support future migrations
+
+### Changed
+- Enhanced `FileScanner.create_file_info()` to include `modified` (timestamp) and `size_bytes` fields
+- Updated `CacheManager` to track index version for migration support
+- Settings page now automatically triggers index migration when needed
+
+### Technical Details
+- Index version constant: `3.1.0`
+- New cache manager constants: `INDEX_VERSION_OPTION_NAME`, `CURRENT_INDEX_VERSION`
+- New `IndexBuilder` method: `check_and_migrate_index()` for automatic migration
+- New `Settings` method: `check_and_perform_migration()` for migration handling
+
+### Migration Notes
+- Existing indexes will be automatically migrated when the settings page is accessed
+- Users will see a notification when the index is updated with new metadata
+- No manual action required - the migration is automatic and transparent
+
+## [3.0.0] - 2025-08-30
+
+### Added
+- Complete architectural overhaul to PSR-4 compliant structure
+- Dependency injection container system
+- Comprehensive service layer architecture
+- Admin settings page with directory selection
+- Folder File Listing Viewer for reviewing indexed PDFs
+- Debug logging system
+- Self-test system for plugin diagnostics
+- Backward compatibility with v2.x settings and indexes
+
+### Changed
+- Migrated from procedural to object-oriented architecture
+- Reorganized codebase into logical namespaces
+- Improved error handling and logging
+
+### Fixed
+- Various stability and performance improvements
+
+---
+
+*For more information, visit [KISS Plugins](https://KISSplugins.com)*
+

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -212,8 +212,28 @@
     .kapl-test-result {
         padding: 10px;
     }
-    
+
     .kapl-test-summary {
         padding: 12px;
     }
+}
+
+
+/* High-contrast total files summary for Folder Viewer */
+.kapl-folder-viewer__total{
+    margin: 8px 20px 12px;
+    padding: 6px 10px;
+    background: #111;
+    color: #fff;
+    border: 1px solid #2a2a2a;
+    border-radius: 4px;
+    font-weight: 600;
+    display: inline-block;
+}
+
+/* Row number prefix styling */
+.kapl-rownum{
+    color: #9ecbff;
+    font-weight: 700;
+    margin-right: 4px;
 }

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -109,8 +109,8 @@
 }
 
 .kapl-folder-viewer__table-wrapper {
-    padding: 0 20px 12px;
-    overflow-x: auto;
+    padding: 0 20px 16px !important;
+    overflow-x: auto !important;
 }
 
 .kapl-folder-viewer__table {
@@ -122,18 +122,43 @@
 
 .kapl-folder-viewer__table th,
 .kapl-folder-viewer__table td {
-    padding: 10px 12px;
-    border-bottom: 1px solid #1e1e1e;
-    text-align: left;
-    vertical-align: top;
+    padding: 12px 16px !important;
+    border-bottom: 1px solid #1e1e1e !important;
+    text-align: left !important;
+    vertical-align: top !important;
 }
 
 .kapl-folder-viewer__table th {
-    font-weight: 600;
-    background: #111;
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    font-weight: 600 !important;
+    background: #111 !important;
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 1 !important;
+}
+
+/* Column 1: File Name - Left aligned with left padding */
+.kapl-folder-viewer__table th:nth-child(1),
+.kapl-folder-viewer__table td:nth-child(1) {
+    width: 45% !important;
+    min-width: 250px !important;
+    padding: 12px 16px 12px 20px !important;
+}
+
+/* Column 2: Modified Date - Center column with balanced padding */
+.kapl-folder-viewer__table th:nth-child(2),
+.kapl-folder-viewer__table td:nth-child(2) {
+    width: 30% !important;
+    min-width: 180px !important;
+    padding: 12px 40px 12px 16px !important;
+}
+
+/* Column 3: File Size - Right aligned with extra left padding for spacing */
+.kapl-folder-viewer__table th:nth-child(3),
+.kapl-folder-viewer__table td:nth-child(3) {
+    width: 25% !important;
+    min-width: 120px !important;
+    text-align: right !important;
+    padding: 12px 20px 12px 40px !important;
 }
 
 .kapl-folder-viewer__table tr:last-child td {
@@ -163,6 +188,23 @@
     color: #c5c5c5;
     font-style: italic;
     padding: 0 20px 12px;
+}
+
+/* Column-specific styling */
+.kapl-folder-viewer__filename {
+    word-break: break-word !important;
+}
+
+.kapl-folder-viewer__modified {
+    white-space: nowrap !important;
+    color: #a8a8a8 !important;
+    font-size: 13px !important;
+}
+
+.kapl-folder-viewer__size {
+    white-space: nowrap !important;
+    color: #a8a8a8 !important;
+    font-size: 13px !important;
 }
 
 /* Responsive adjustments */

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -80,6 +80,91 @@
     margin-right: 10px;
 }
 
+.kapl-folder-viewer {
+    margin-top: 15px;
+    color: #fff;
+}
+
+.kapl-folder-viewer__folder {
+    margin-bottom: 16px;
+    border: 1px solid #1e1e1e;
+    border-radius: 6px;
+    background: #000;
+    padding: 0 0 12px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
+}
+
+.kapl-folder-viewer__folder > summary {
+    cursor: pointer;
+    font-weight: 600;
+    margin: 0 0 12px;
+    padding: 16px 20px;
+    background: #111;
+    border-bottom: 1px solid #1e1e1e;
+    color: #fff;
+}
+
+.kapl-folder-viewer__folder[open] > summary {
+    border-bottom-color: #2a2a2a;
+}
+
+.kapl-folder-viewer__table-wrapper {
+    padding: 0 20px 12px;
+    overflow-x: auto;
+}
+
+.kapl-folder-viewer__table {
+    width: 100%;
+    border-collapse: collapse;
+    background: transparent;
+    color: inherit;
+}
+
+.kapl-folder-viewer__table th,
+.kapl-folder-viewer__table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #1e1e1e;
+    text-align: left;
+    vertical-align: top;
+}
+
+.kapl-folder-viewer__table th {
+    font-weight: 600;
+    background: #111;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.kapl-folder-viewer__table tr:last-child td {
+    border-bottom: none;
+}
+
+.kapl-folder-viewer__file a {
+    color: #5fb3ff;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.kapl-folder-viewer__file a:hover,
+.kapl-folder-viewer__file a:focus {
+    text-decoration: underline;
+}
+
+.kapl-folder-viewer__path {
+    display: block;
+    font-size: 12px;
+    color: #c5c5c5;
+    margin-top: 4px;
+}
+
+.kapl-folder-viewer__empty {
+    margin: 0;
+    color: #c5c5c5;
+    font-style: italic;
+    padding: 0 20px 12px;
+}
+
 /* Responsive adjustments */
 @media (max-width: 782px) {
     .kapl-test-result {

--- a/kiss-automated-pdf-linker-v3.php
+++ b/kiss-automated-pdf-linker-v3.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS Automated PDF Linker (PSR4)
  * Plugin URI:        https://github.com/kissplugins/KISS-automated-pdf-linker
  * Description:       Scans selected upload directories for PDF files and provides a shortcode [kiss_pdf name="filename"] to link to them using fuzzy matching.
- * Version:           3.0.0
+ * Version:           3.1.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            KISS / Neochrome, Inc.
@@ -99,7 +99,7 @@ register_deactivation_hook( __FILE__, 'kapl_deactivate_plugin' );
 
 // Backward compatibility constants for any external code that might reference them
 if ( ! defined( 'KAPL_VERSION' ) ) {
-    define( 'KAPL_VERSION', '3.0.0' );
+    define( 'KAPL_VERSION', '3.1.0' );
 }
 if ( ! defined( 'KAPL_PLUGIN_DIR' ) ) {
     define( 'KAPL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/kiss-automated-pdf-linker-v3.php
+++ b/kiss-automated-pdf-linker-v3.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS Automated PDF Linker (PSR4)
  * Plugin URI:        https://github.com/kissplugins/KISS-automated-pdf-linker
  * Description:       Scans selected upload directories for PDF files and provides a shortcode [kiss_pdf name="filename"] to link to them using fuzzy matching.
- * Version:           3.1.3
+ * Version:           3.1.4
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            KISS / Neochrome, Inc.
@@ -99,7 +99,7 @@ register_deactivation_hook( __FILE__, 'kapl_deactivate_plugin' );
 
 // Backward compatibility constants for any external code that might reference them
 if ( ! defined( 'KAPL_VERSION' ) ) {
-    define( 'KAPL_VERSION', '3.1.3' );
+    define( 'KAPL_VERSION', '3.1.4' );
 }
 if ( ! defined( 'KAPL_PLUGIN_DIR' ) ) {
     define( 'KAPL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/kiss-automated-pdf-linker-v3.php
+++ b/kiss-automated-pdf-linker-v3.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS Automated PDF Linker (PSR4)
  * Plugin URI:        https://github.com/kissplugins/KISS-automated-pdf-linker
  * Description:       Scans selected upload directories for PDF files and provides a shortcode [kiss_pdf name="filename"] to link to them using fuzzy matching.
- * Version:           3.1.0
+ * Version:           3.1.3
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            KISS / Neochrome, Inc.
@@ -99,7 +99,7 @@ register_deactivation_hook( __FILE__, 'kapl_deactivate_plugin' );
 
 // Backward compatibility constants for any external code that might reference them
 if ( ! defined( 'KAPL_VERSION' ) ) {
-    define( 'KAPL_VERSION', '3.1.0' );
+    define( 'KAPL_VERSION', '3.1.3' );
 }
 if ( ! defined( 'KAPL_PLUGIN_DIR' ) ) {
     define( 'KAPL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -60,6 +60,9 @@ class AdminMenu {
             return;
         }
 
+        // Check for index migration (e.g., adding new metadata fields)
+        $this->settings->check_and_perform_migration();
+
         // Handle index rebuilding action
         $this->settings->handle_index_rebuild();
 
@@ -68,6 +71,7 @@ class AdminMenu {
             <h1><?php echo \esc_html( \get_admin_page_title() ); ?></h1>
 
             <?php \settings_errors( 'kapl_rebuild_status' ); ?>
+            <?php \settings_errors( 'kapl_migration_status' ); ?>
 
             <form method="post" action="options.php">
                 <?php
@@ -225,7 +229,7 @@ class AdminMenu {
                 }
 
                 echo '<tr class="kapl-folder-viewer__file">';
-                echo '<td>';
+                echo '<td class="kapl-folder-viewer__filename">';
                 echo '<a href="' . esc_url( $file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $file_name ) . '</a>';
 
                 if ( '' !== $display_path && $display_path !== $file_name ) {
@@ -233,8 +237,8 @@ class AdminMenu {
                 }
 
                 echo '</td>';
-                echo '<td>' . $modified_display . '</td>';
-                echo '<td>' . $size_display . '</td>';
+                echo '<td class="kapl-folder-viewer__modified">' . $modified_display . '</td>';
+                echo '<td class="kapl-folder-viewer__size">' . $size_display . '</td>';
                 echo '</tr>';
             }
 

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -96,6 +96,10 @@ class AdminMenu {
 
             <hr>
 
+            <?php $this->render_folder_file_listing_viewer(); ?>
+
+            <hr>
+
             <h2><?php \esc_html_e( 'System Self-Tests', 'kiss-automated-pdf-linker' ); ?></h2>
             <p><?php \esc_html_e( 'Run diagnostic tests to verify plugin functionality and catch potential issues.', 'kiss-automated-pdf-linker' ); ?></p>
 
@@ -120,13 +124,13 @@ class AdminMenu {
      */
     private function render_index_status(): void {
         $index_stats = $this->settings->get_index_builder()->get_index_stats();
-        
+
         echo '<p><em>' . \esc_html( $index_stats['message'] ) . '</em></p>';
-        
+
         if ( 'ready' === $index_stats['status'] ) {
             echo '<details>';
             echo '<summary>' . \esc_html__( 'Index Details', 'kiss-automated-pdf-linker' ) . '</summary>';
-            
+
             $validation = $this->settings->get_index_builder()->validate_index();
             if ( $validation['is_valid'] ) {
                 echo '<p style="color: green;">✓ ' . \esc_html__( 'Index is valid', 'kiss-automated-pdf-linker' ) . '</p>';
@@ -136,8 +140,110 @@ class AdminMenu {
                     echo '<p style="color: red; margin-left: 20px;">• ' . \esc_html( $error ) . '</p>';
                 }
             }
-            
+
             echo '</details>';
         }
+    }
+
+    /**
+     * Render the folder file listing viewer.
+     *
+     * @return void
+     */
+    private function render_folder_file_listing_viewer(): void {
+        $settings = $this->settings->get_settings();
+        $selected_directories = $settings['selected_directories'] ?? [];
+
+        echo '<h2>' . \esc_html__( 'Folder File Listing Viewer', 'kiss-automated-pdf-linker' ) . '</h2>';
+        echo '<p>' . \esc_html__( 'Review the PDF files that were discovered in each selected folder. Click a file name to open it in a new tab.', 'kiss-automated-pdf-linker' ) . '</p>';
+
+        if ( empty( $selected_directories ) ) {
+            echo '<p><em>' . \esc_html__( 'No folders have been selected for scanning yet. Choose folders above and rebuild the index to see their contents.', 'kiss-automated-pdf-linker' ) . '</em></p>';
+            return;
+        }
+
+        $grouped_files = $this->settings->get_index_builder()->get_index_by_directory( $selected_directories );
+
+        if ( empty( $grouped_files ) ) {
+            echo '<p><em>' . \esc_html__( 'The index does not contain any PDFs yet. Rebuild the index after selecting folders to populate this viewer.', 'kiss-automated-pdf-linker' ) . '</em></p>';
+            return;
+        }
+
+        $upload_dir_info = wp_upload_dir();
+        $base_url = trailingslashit( $upload_dir_info['baseurl'] );
+
+        echo '<div class="kapl-folder-viewer">';
+
+        foreach ( $selected_directories as $directory ) {
+            $files = $grouped_files[ $directory ] ?? [];
+
+            echo '<details class="kapl-folder-viewer__folder" open>';
+            echo '<summary>' . \esc_html( $directory ) . '/</summary>';
+
+            if ( empty( $files ) ) {
+                echo '<p class="kapl-folder-viewer__empty">' . \esc_html__( 'No PDF files found in this folder.', 'kiss-automated-pdf-linker' ) . '</p>';
+                echo '</details>';
+                continue;
+            }
+
+            echo '<div class="kapl-folder-viewer__table-wrapper">';
+            echo '<table class="kapl-folder-viewer__table">';
+            echo '<thead>';
+            echo '<tr>';
+            echo '<th scope="col">' . \esc_html__( 'File Name', 'kiss-automated-pdf-linker' ) . '</th>';
+            echo '<th scope="col">' . \esc_html__( 'Modified Date', 'kiss-automated-pdf-linker' ) . '</th>';
+            echo '<th scope="col">' . \esc_html__( 'File Size (KB)', 'kiss-automated-pdf-linker' ) . '</th>';
+            echo '</tr>';
+            echo '</thead>';
+            echo '<tbody>';
+
+            foreach ( $files as $file ) {
+                $relative_path = isset( $file['path'] ) ? (string) $file['path'] : '';
+                $file_name = isset( $file['filename'] ) ? (string) $file['filename'] : basename( $relative_path );
+
+                if ( '' === $relative_path ) {
+                    continue;
+                }
+
+                $file_url = $base_url . ltrim( $relative_path, '/' );
+                $folder_prefix = $directory . '/';
+                $display_path = $relative_path;
+                $modified_display = '&mdash;';
+                $size_display = '&mdash;';
+
+                if ( 0 === strpos( $relative_path, $folder_prefix ) ) {
+                    $display_path = substr( $relative_path, strlen( $folder_prefix ) );
+                }
+
+                if ( isset( $file['modified'] ) && is_numeric( $file['modified'] ) ) {
+                    $modified_display = \esc_html( \date_i18n( \get_option( 'date_format' ) . ' ' . \get_option( 'time_format' ), (int) $file['modified'] ) );
+                }
+
+                if ( isset( $file['size_bytes'] ) && is_numeric( $file['size_bytes'] ) ) {
+                    $kilobytes = (int) $file['size_bytes'] / 1024;
+                    $size_display = \esc_html( number_format_i18n( max( $kilobytes, 0 ), 1 ) );
+                }
+
+                echo '<tr class="kapl-folder-viewer__file">';
+                echo '<td>';
+                echo '<a href="' . esc_url( $file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $file_name ) . '</a>';
+
+                if ( '' !== $display_path && $display_path !== $file_name ) {
+                    echo '<span class="kapl-folder-viewer__path">' . esc_html( $display_path ) . '</span>';
+                }
+
+                echo '</td>';
+                echo '<td>' . $modified_display . '</td>';
+                echo '<td>' . $size_display . '</td>';
+                echo '</tr>';
+            }
+
+            echo '</tbody>';
+            echo '</table>';
+            echo '</div>';
+            echo '</details>';
+        }
+
+        echo '</div>';
     }
 }

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -193,13 +193,9 @@ class AdminMenu {
             return;
         }
 
-        // Compute total number of files across all selected directories (for summary at top).
-        $total_files_count = 0;
-        foreach ( $selected_directories as $dir_for_count ) {
-            if ( isset( $grouped_files[ $dir_for_count ] ) && is_array( $grouped_files[ $dir_for_count ] ) ) {
-                $total_files_count += count( $grouped_files[ $dir_for_count ] );
-            }
-        }
+        // DRY: Re-use IndexBuilder::get_index_stats() so the count matches the status panel and rebuild message.
+        $index_stats = $this->settings->get_index_builder()->get_index_stats();
+        $total_files_count = isset( $index_stats['total_files'] ) ? (int) $index_stats['total_files'] : 0;
 
         $upload_dir_info = wp_upload_dir();
         $base_url = trailingslashit( $upload_dir_info['baseurl'] );

--- a/src/Admin/AdminMenu.php
+++ b/src/Admin/AdminMenu.php
@@ -39,6 +39,14 @@ class AdminMenu {
      * @return void
      */
     public function add_admin_menu(): void {
+        /*
+         * IMPORTANT: This settings screen is registered under Tools via add_management_page().
+         * That produces an admin hook like `tools_page_{slug}` rather than `settings_page_{slug}`.
+         * The Assets::enqueue_scripts() guard uses a slug substring match to support both contexts
+         * in case this screen ever moves. Do not change registration context unless you also
+         * update the asset loader accordingly.
+         */
+
         \add_management_page(
             \__( 'KISS PDF Linker Settings', 'kiss-automated-pdf-linker' ),
             \__( 'KISS PDF Linker', 'kiss-automated-pdf-linker' ),
@@ -161,6 +169,18 @@ class AdminMenu {
         echo '<h2>' . \esc_html__( 'Folder File Listing Viewer', 'kiss-automated-pdf-linker' ) . '</h2>';
         echo '<p>' . \esc_html__( 'Review the PDF files that were discovered in each selected folder. Click a file name to open it in a new tab.', 'kiss-automated-pdf-linker' ) . '</p>';
 
+
+        $kapl_debug_enabled = ( isset($_GET['kapl_debug']) && '1' === (string) $_GET['kapl_debug'] );
+        if ( ! $kapl_debug_enabled ) {
+            $kapl_settings = get_option( \KissPlugins\AutomatedPdfLinker\Admin\Settings::SETTINGS_OPTION_NAME, [] );
+            $kapl_debug_enabled = ! empty( $kapl_settings['on_screen_debug'] );
+        }
+        $kapl_debug_toggle_url = esc_url( add_query_arg( 'kapl_debug', $kapl_debug_enabled ? '0' : '1' ) );
+        echo '<p><a href="' . $kapl_debug_toggle_url . '" class="button button-small">' . ( $kapl_debug_enabled ? esc_html__( 'Disable Debug', 'kiss-automated-pdf-linker' ) : esc_html__( 'Enable Debug', 'kiss-automated-pdf-linker' ) ) . '</a></p>';
+        if ( $kapl_debug_enabled ) {
+            echo '<div id="kapl-debug-panel" class="kapl-debug-panel" aria-live="polite"></div>';
+        }
+
         if ( empty( $selected_directories ) ) {
             echo '<p><em>' . \esc_html__( 'No folders have been selected for scanning yet. Choose folders above and rebuild the index to see their contents.', 'kiss-automated-pdf-linker' ) . '</em></p>';
             return;
@@ -173,10 +193,23 @@ class AdminMenu {
             return;
         }
 
+        // Compute total number of files across all selected directories (for summary at top).
+        $total_files_count = 0;
+        foreach ( $selected_directories as $dir_for_count ) {
+            if ( isset( $grouped_files[ $dir_for_count ] ) && is_array( $grouped_files[ $dir_for_count ] ) ) {
+                $total_files_count += count( $grouped_files[ $dir_for_count ] );
+            }
+        }
+
         $upload_dir_info = wp_upload_dir();
         $base_url = trailingslashit( $upload_dir_info['baseurl'] );
 
         echo '<div class="kapl-folder-viewer">';
+            // Show total number of files at the top of the list.
+            echo '<p class="kapl-folder-viewer__total"><strong>' . sprintf( \esc_html__( 'Total files: %d', 'kiss-automated-pdf-linker' ), (int) $total_files_count ) . '</strong></p>';
+
+        // Global, cross-folder running row number starting at 1 (requested UI)
+        $row_number = 1;
 
         foreach ( $selected_directories as $directory ) {
             $files = $grouped_files[ $directory ] ?? [];
@@ -191,7 +224,7 @@ class AdminMenu {
             }
 
             echo '<div class="kapl-folder-viewer__table-wrapper">';
-            echo '<table class="kapl-folder-viewer__table">';
+            echo '<table class="kapl-folder-viewer__table"' . ( $kapl_debug_enabled ? ' data-kapl-debug="1"' : '' ) . '>';
             echo '<thead>';
             echo '<tr>';
             echo '<th scope="col">' . \esc_html__( 'File Name', 'kiss-automated-pdf-linker' ) . '</th>';
@@ -230,6 +263,8 @@ class AdminMenu {
 
                 echo '<tr class="kapl-folder-viewer__file">';
                 echo '<td class="kapl-folder-viewer__filename">';
+                // Prepend running row number like "1.) " before the filename link (does not reset per folder)
+                echo '<span class="kapl-rownum">' . (int) $row_number . '.) </span>';
                 echo '<a href="' . esc_url( $file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $file_name ) . '</a>';
 
                 if ( '' !== $display_path && $display_path !== $file_name ) {
@@ -238,6 +273,9 @@ class AdminMenu {
 
                 echo '</td>';
                 echo '<td class="kapl-folder-viewer__modified">' . $modified_display . '</td>';
+                // Increment global row number after rendering this row
+                $row_number++;
+
                 echo '<td class="kapl-folder-viewer__size">' . $size_display . '</td>';
                 echo '</tr>';
             }

--- a/src/Admin/Assets.php
+++ b/src/Admin/Assets.php
@@ -24,13 +24,23 @@ class Assets {
      * @return void
      */
     public static function enqueue_scripts( string $hook ): void {
-        // Only load on our settings page
-        if ( 'settings_page_' . Settings::SETTINGS_SLUG !== $hook ) {
+        // Only load on our plugin screen (works for both Tools and Settings contexts)
+        /*
+         * IMPORTANT: Do NOT refactor this to a strict `settings_page_` prefix check.
+         * - Our admin page is registered via add_management_page(), which produces hook ids like `tools_page_{slug}`.
+         * - In earlier attempts, checking exclusively for `settings_page_...` caused assets (incl. debug inline JS) not to load.
+         * - Using a slug substring match (strpos) is deliberate and resilient: it works for Tools now and will also work if
+         *   we ever move the screen under Settings (yielding `settings_page_{slug}`).
+         */
+        if ( false === strpos( (string) $hook, Settings::SETTINGS_SLUG ) ) {
             return;
         }
 
         self::enqueue_admin_styles();
         self::enqueue_color_picker();
+        if ( self::is_debug_enabled() ) {
+            self::enqueue_debug_tools();
+        }
     }
 
     /**
@@ -45,7 +55,7 @@ class Assets {
             'kapl-admin-styles',
             $plugin_url . 'assets/admin.css',
             [],
-            '3.0.1'
+            '3.0.2'
         );
     }
 
@@ -74,5 +84,119 @@ class Assets {
                 $(".kapl-color-picker").wpColorPicker();
             });
         ' );
+        }
+
+
+    /**
+     * Whether on-page debug should be enabled.
+     */
+    private static function is_debug_enabled(): bool {
+        // URL toggle has priority
+        if ( isset($_GET['kapl_debug']) ) {
+            return '1' === (string) $_GET['kapl_debug'];
+        }
+        // Fallback to saved setting
+        $settings = \get_option( Settings::SETTINGS_OPTION_NAME, [] );
+        return ! empty( $settings['on_screen_debug'] );
     }
+
+    /**
+     * Enqueue on-page debugging helpers (panel + measurements) for the Folder Viewer.
+     * Only runs when kapl_debug=1 is present in the URL.
+     */
+    private static function enqueue_debug_tools(): void {
+        // Prepare data about the admin stylesheet.
+        $wp_styles = \wp_styles();
+        $handle    = 'kapl-admin-styles';
+        $registered = isset($wp_styles->registered[$handle]) ? $wp_styles->registered[$handle] : null;
+
+        $plugin_dir = \plugin_dir_path( dirname( dirname( __DIR__ ) ) . '/kiss-automated-pdf-linker-v3.php' );
+        $css_path   = $plugin_dir . 'assets/admin.css';
+        $css_mtime  = file_exists($css_path) ? (int) filemtime($css_path) : 0;
+
+        // Attach debug data to the existing admin script handle so inline code always prints.
+        $data = [
+            'style_handle'   => $handle,
+            'style_enqueued' => \wp_style_is($handle, 'enqueued'),
+            'style_done'     => \wp_style_is($handle, 'done'),
+            'style_src'      => $registered ? $registered->src : '',
+            'style_ver'      => $registered ? $registered->ver : '',
+            'style_mtime'    => $css_mtime,
+            'plugin_version' => defined('KAPL_VERSION') ? KAPL_VERSION : 'unknown',
+            'wp_debug'       => defined('WP_DEBUG') ? (bool) WP_DEBUG : false,
+        ];
+
+        \wp_localize_script('kapl-admin-script', 'KAPL_DEBUG_DATA', $data);
+
+        // Inline styles to visually highlight columns and the debug panel.
+        \wp_add_inline_style(
+            'kapl-admin-styles',
+            '.kapl-debug-panel{margin:10px 0;padding:10px;background:#111;color:#fff;border:1px solid #333;border-radius:6px}' .
+            '.kapl-debug-panel code{background:#222;padding:2px 4px;border-radius:3px}' .
+            '.kapl-folder-viewer__filename{background:rgba(0,128,255,.06)}' .
+            '.kapl-folder-viewer__modified{background:rgba(0,255,128,.06)}' .
+            '.kapl-folder-viewer__size{background:rgba(255,128,0,.06)}'
+        );
+
+        // Inline script: builds a debug panel and measures column widths / table layout.
+        \wp_add_inline_script('kapl-admin-script', "(function(){
+            try {
+                var container = document.querySelector('.kapl-folder-viewer');
+                if(!container){ return; }
+                var panel = document.getElementById('kapl-debug-panel');
+                if(!panel){
+                    panel = document.createElement('div');
+                    panel.id = 'kapl-debug-panel';
+                    panel.className = 'kapl-debug-panel';
+                    container.parentNode.insertBefore(panel, container);
+                }
+
+                var table = container.querySelector('.kapl-folder-viewer__table');
+                var layout = table ? getComputedStyle(table).getPropertyValue('table-layout') : 'n/a';
+                var widths = [];
+                var paddings = [];
+                var firstRow = table && table.tBodies && table.tBodies[0] ? table.tBodies[0].rows[0] : null;
+                if(firstRow){
+                    var cells = Array.from(firstRow.cells);
+                    cells.forEach(function(td, i){
+                        var rect = td.getBoundingClientRect();
+                        widths.push(Math.round(rect.width)+'px');
+                        var cs = getComputedStyle(td);
+                        paddings.push(cs.paddingLeft+' | '+cs.paddingRight);
+                    });
+                }
+
+                // Detect if our CSS file is present in the DOM
+                var linkTags = Array.from(document.querySelectorAll('link[rel=\'stylesheet\']'));
+                var cssLink = linkTags.find(function(l){ return (l.href||'').indexOf('assets/admin.css') !== -1; });
+                var styleSheetFound = !!cssLink;
+
+                // Also verify via styleSheets API
+                var ssMatch = Array.from(document.styleSheets).find(function(s){ return (s.href||'').indexOf('assets/admin.css') !== -1; });
+
+                var html = ''+
+                  '<strong>KAPL Folder Viewer Debug</strong><br>'+
+                  '<div style=\'margin-top:6px\'>CSS handle: <code>'+KAPL_DEBUG_DATA.style_handle+'</code> | enqueued: <code>'+KAPL_DEBUG_DATA.style_enqueued+'</code> | done: <code>'+KAPL_DEBUG_DATA.style_done+'</code></div>'+
+                  '<div>registered src: <code>'+(KAPL_DEBUG_DATA.style_src||'(none)')+'</code> | ver: <code>'+(KAPL_DEBUG_DATA.style_ver||'(none)')+'</code> | filemtime: <code>'+KAPL_DEBUG_DATA.style_mtime+'</code></div>'+
+                  '<div>DOM stylesheet link present: <code>'+styleSheetFound+'</code> | styleSheets match: <code>'+!!ssMatch+'</code></div>'+
+                  '<div>Plugin version: <code>'+KAPL_DEBUG_DATA.plugin_version+'</code> | WP_DEBUG: <code>'+KAPL_DEBUG_DATA.wp_debug+'</code></div>'+
+                  '<div>Table layout: <code>'+layout+'</code></div>'+
+                  (widths.length ? '<div>First row cell widths: <code>'+widths.join(' , ')+'</code></div>' : '<div>No rows found to measure.</div>')+
+                  (paddings.length ? '<div>First row cell paddings (L | R): <code>'+paddings.join(' , ')+'</code></div>' : '');
+
+                // Hinting
+                var hint = '';
+                if(layout === 'auto' && widths.length >= 3){
+                    var w1 = parseInt(widths[0]); var w2 = parseInt(widths[1]); var w3 = parseInt(widths[2]);
+                    if(w1 > (w2+w3)){
+                        hint = 'The File Name column dominates width with table-layout:auto. Consider table-layout: fixed; or a <colgroup> to enforce widths.';
+                    }
+                }
+                if(hint){ html += '<div style=\'margin-top:6px;color:#ffcc00\'><em>Hint:</em> '+hint+'</div>'; }
+
+                panel.innerHTML = html;
+            } catch(e) { console && console.warn && console.warn('KAPL debug init error', e); }
+        })();");
+    }
+
 }

--- a/src/Admin/Assets.php
+++ b/src/Admin/Assets.php
@@ -45,7 +45,7 @@ class Assets {
             'kapl-admin-styles',
             $plugin_url . 'assets/admin.css',
             [],
-            '3.0.0'
+            '3.0.1'
         );
     }
 

--- a/src/Admin/Assets.php
+++ b/src/Admin/Assets.php
@@ -55,7 +55,7 @@ class Assets {
             'kapl-admin-styles',
             $plugin_url . 'assets/admin.css',
             [],
-            '3.0.2'
+            '3.0.3'
         );
     }
 

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -160,6 +160,15 @@ class Settings {
             self::SETTINGS_SLUG,
             'kapl_debug_section'
         );
+
+            \add_settings_field(
+                'kapl_on_screen_debug',
+                \__( 'Enable on-screen debug panel', 'kiss-automated-pdf-linker' ),
+                [ $this, 'on_screen_debug_field_callback' ],
+                self::SETTINGS_SLUG,
+                'kapl_debug_section'
+            );
+
     }
 
 
@@ -191,6 +200,7 @@ class Settings {
         // Sanitize checkboxes
         $sanitized_input['use_product_title_match'] = isset( $input['use_product_title_match'] );
         $sanitized_input['debug_logging'] = isset( $input['debug_logging'] );
+        $sanitized_input['on_screen_debug'] = isset( $input['on_screen_debug'] );
 
         return $sanitized_input;
     }
@@ -206,6 +216,7 @@ class Settings {
             'link_color'              => '#0000FF',
             'use_product_title_match' => false,
             'debug_logging'           => false,
+            'on_screen_debug'         => false,
         ] );
     }
 
@@ -272,12 +283,12 @@ class Settings {
         $settings = $this->get_settings();
         $link_color = $settings['link_color'];
         ?>
-        <input 
-            type="text" 
-            name="<?php echo esc_attr( self::SETTINGS_OPTION_NAME ); ?>[link_color]" 
-            id="kapl_link_color" 
-            value="<?php echo esc_attr( $link_color ); ?>" 
-            class="kapl-color-picker" 
+        <input
+            type="text"
+            name="<?php echo esc_attr( self::SETTINGS_OPTION_NAME ); ?>[link_color]"
+            id="kapl_link_color"
+            value="<?php echo esc_attr( $link_color ); ?>"
+            class="kapl-color-picker"
         />
         <p class="description">
             <?php esc_html_e( 'Choose the color for PDF links. This will be applied to all links with the kapl-pdf-link class.', 'kiss-automated-pdf-linker' ); ?>
@@ -295,11 +306,11 @@ class Settings {
         $use_product_title_match = $settings['use_product_title_match'];
         ?>
         <label for="kapl_use_product_title_match">
-            <input 
-                type="checkbox" 
-                name="<?php echo esc_attr( self::SETTINGS_OPTION_NAME ); ?>[use_product_title_match]" 
-                id="kapl_use_product_title_match" 
-                value="1" 
+            <input
+                type="checkbox"
+                name="<?php echo esc_attr( self::SETTINGS_OPTION_NAME ); ?>[use_product_title_match]"
+                id="kapl_use_product_title_match"
+                value="1"
                 <?php checked( $use_product_title_match, true ); ?>
             />
             <?php esc_html_e( 'Enable automatic PDF linking for strains in the product tab.', 'kiss-automated-pdf-linker' ); ?>
@@ -316,7 +327,7 @@ class Settings {
      * @return void
      */
     public function debug_section_callback(): void {
-        echo '<p>' . esc_html__( 'Toggle debug output to the PHP error log.', 'kiss-automated-pdf-linker' ) . '</p>';
+        echo '<p>' . esc_html__( 'Enable write-to-log debugging and/or the on-screen debug panel for the Folder File Listing Viewer.', 'kiss-automated-pdf-linker' ) . '</p>';
     }
 
     /**
@@ -341,9 +352,30 @@ class Settings {
         <?php
     }
 
-
-
-
+    /**
+     * On-screen debug field callback.
+     *
+     * @return void
+     */
+    public function on_screen_debug_field_callback(): void {
+        $settings = $this->get_settings();
+        $enabled = ! empty( $settings['on_screen_debug'] );
+        ?>
+        <label for="kapl_on_screen_debug">
+            <input
+                type="checkbox"
+                name="<?php echo esc_attr( self::SETTINGS_OPTION_NAME ); ?>[on_screen_debug]"
+                id="kapl_on_screen_debug"
+                value="1"
+                <?php checked( $enabled, true ); ?>
+            />
+            <?php esc_html_e( 'Show the on-screen debug panel for the Folder File Listing Viewer.', 'kiss-automated-pdf-linker' ); ?>
+        </label>
+        <p class="description">
+            <?php esc_html_e( 'You can also toggle ad-hoc via the URL parameter kapl_debug=1.', 'kiss-automated-pdf-linker' ); ?>
+        </p>
+        <?php
+    }
 
     /**
      * Check if index needs migration and perform it if necessary.

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -346,6 +346,31 @@ class Settings {
 
 
     /**
+     * Check if index needs migration and perform it if necessary.
+     *
+     * @return void
+     */
+    public function check_and_perform_migration(): void {
+        $settings = $this->get_settings();
+        $selected_directories = $settings['selected_directories'] ?? [];
+
+        if ( empty( $selected_directories ) ) {
+            return;
+        }
+
+        $migration_performed = $this->index_builder->check_and_migrate_index( $selected_directories );
+
+        if ( $migration_performed ) {
+            \add_settings_error(
+                'kapl_migration_status',
+                'migration_success',
+                \esc_html__( 'PDF index was automatically updated to include file metadata (modified date and file size).', 'kiss-automated-pdf-linker' ),
+                'updated'
+            );
+        }
+    }
+
+    /**
      * Handle index rebuilding if requested.
      *
      * @return void

--- a/src/Services/CacheManager.php
+++ b/src/Services/CacheManager.php
@@ -30,6 +30,16 @@ class CacheManager {
     const INDEX_FILE_PATH = 'pdf-index.json';
 
     /**
+     * Index version option name.
+     */
+    const INDEX_VERSION_OPTION_NAME = 'kapl_pdf_index_version';
+
+    /**
+     * Current index version.
+     */
+    const CURRENT_INDEX_VERSION = '3.1.0';
+
+    /**
      * Logger instance.
      *
      * @var Logger
@@ -106,6 +116,26 @@ class CacheManager {
     }
 
     /**
+     * Check if index needs migration to include new metadata fields.
+     *
+     * @return bool True if index needs migration, false otherwise.
+     */
+    public function needs_index_migration(): bool {
+        if ( ! function_exists( 'get_option' ) ) {
+            return false;
+        }
+
+        $index_version = \get_option( self::INDEX_VERSION_OPTION_NAME, '3.0.0' );
+        $needs_migration = version_compare( $index_version, self::CURRENT_INDEX_VERSION, '<' );
+
+        if ( $needs_migration ) {
+            $this->logger->info( "Index migration needed: current version {$index_version}, target version " . self::CURRENT_INDEX_VERSION );
+        }
+
+        return $needs_migration;
+    }
+
+    /**
      * Update PDF index in cache.
      *
      * @param array $index_data PDF index data.
@@ -133,6 +163,11 @@ class CacheManager {
         if ( ! function_exists( 'update_option' ) ) {
             $this->logger->debug( 'WordPress functions not available, using file storage.' );
             return $this->save_index_to_file( $index_data );
+        }
+
+        // Update index version
+        if ( function_exists( 'update_option' ) ) {
+            \update_option( self::INDEX_VERSION_OPTION_NAME, self::CURRENT_INDEX_VERSION, 'no' );
         }
 
         // Check if the JSON is too large (WordPress typically has issues with options > 1MB)

--- a/src/Services/FileScanner.php
+++ b/src/Services/FileScanner.php
@@ -157,9 +157,11 @@ class FileScanner {
         $normalized_name = FileNormalizer::normalize( $filename );
 
         return [
-            'path'            => $relative_path,  // e.g., '2024/04/document.pdf' or 'coas/report.pdf'
-            'filename'        => $filename,       // e.g., 'document.pdf'
-            'normalized_name' => $normalized_name // e.g., 'document'
+            'path'            => $relative_path,              // e.g., '2024/04/document.pdf' or 'coas/report.pdf'
+            'filename'        => $filename,                   // e.g., 'document.pdf'
+            'normalized_name' => $normalized_name,            // e.g., 'document'
+            'modified'        => (int) $fileinfo->getMTime(), // Last modified timestamp.
+            'size_bytes'      => (int) $fileinfo->getSize(),  // Raw file size in bytes.
         ];
     }
 

--- a/src/Services/IndexBuilder.php
+++ b/src/Services/IndexBuilder.php
@@ -54,6 +54,31 @@ class IndexBuilder {
     }
 
     /**
+     * Check if index needs migration and rebuild if necessary.
+     *
+     * @param array $selected_directories Array of directory names to scan.
+     * @return bool True if migration was performed, false otherwise.
+     */
+    public function check_and_migrate_index( array $selected_directories ): bool {
+        if ( ! $this->cache_manager->needs_index_migration() ) {
+            return false;
+        }
+
+        $this->logger->info( 'Index migration detected. Rebuilding index with new metadata fields.' );
+
+        // Rebuild the index to include new metadata fields
+        $result = $this->build_index( $selected_directories );
+
+        if ( is_wp_error( $result ) ) {
+            $this->logger->error( 'Index migration failed: ' . $result->get_error_message() );
+            return false;
+        }
+
+        $this->logger->info( "Index migration completed successfully. Indexed {$result} files with new metadata." );
+        return true;
+    }
+
+    /**
      * Build PDF index from selected directories.
      *
      * @param array $selected_directories Array of directory names to scan.
@@ -71,9 +96,9 @@ class IndexBuilder {
 
         try {
             $pdf_files = $this->file_scanner->scan_directories( $selected_directories );
-            
+
             $update_success = $this->cache_manager->update_index( $pdf_files );
-            
+
             if ( ! $update_success ) {
                 $error_message = __( 'Failed to save the PDF index to the database.', 'kiss-automated-pdf-linker' );
                 $this->logger->error( $error_message );
@@ -82,16 +107,16 @@ class IndexBuilder {
 
             $file_count = count( $pdf_files );
             $this->logger->info( "PDF index build completed successfully. Indexed {$file_count} files." );
-            
+
             return $file_count;
-            
+
         } catch ( \Exception $e ) {
             $error_message = sprintf(
                 /* translators: %s: Error message */
                 __( 'Error building PDF index: %s', 'kiss-automated-pdf-linker' ),
                 $e->getMessage()
             );
-            
+
             $this->logger->error( $error_message );
             return new WP_Error( 'build_error', $error_message );
         }

--- a/src/Services/IndexBuilder.php
+++ b/src/Services/IndexBuilder.php
@@ -217,4 +217,43 @@ class IndexBuilder {
     public function get_available_directories(): array {
         return $this->file_scanner->get_available_directories();
     }
+
+    /**
+     * Group index entries by their top-level directory.
+     *
+     * @param array $selected_directories Directories that should be included in the grouping.
+     * @return array<string, array> Array keyed by directory names containing the matching index entries.
+     */
+    public function get_index_by_directory( array $selected_directories ): array {
+        $index = $this->get_index() ?? [];
+
+        if ( empty( $selected_directories ) || empty( $index ) ) {
+            return [];
+        }
+
+        $grouped = [];
+
+        foreach ( $selected_directories as $directory ) {
+            $grouped[ $directory ] = [];
+        }
+
+        foreach ( $index as $item ) {
+            if ( ! isset( $item['path'] ) ) {
+                continue;
+            }
+
+            $relative_path = (string) $item['path'];
+            $top_level_dir = strstr( $relative_path, '/', true );
+
+            if ( false === $top_level_dir ) {
+                $top_level_dir = $relative_path;
+            }
+
+            if ( isset( $grouped[ $top_level_dir ] ) ) {
+                $grouped[ $top_level_dir ][] = $item;
+            }
+        }
+
+        return $grouped;
+    }
 }

--- a/tests/Unit/Services/FileScannerTest.php
+++ b/tests/Unit/Services/FileScannerTest.php
@@ -164,23 +164,25 @@ class FileScannerTest extends TestCase {
      */
     public function test_file_information_extraction(): void {
         $test_file = $this->test_dir . '/test_document.pdf';
-        
+
         // Create a test file with some content
         file_put_contents( $test_file, 'Test PDF content for size testing' );
 
         $results = $this->file_scanner->scan_directory( $this->test_dir );
-        
+
         $this->assertCount( 1, $results );
-        
+
         $file_info = $results[0];
         $this->assertArrayHasKey( 'filename', $file_info );
         $this->assertArrayHasKey( 'path', $file_info );
-        $this->assertArrayHasKey( 'size', $file_info );
+        $this->assertArrayHasKey( 'size_bytes', $file_info );
+        $this->assertArrayHasKey( 'modified', $file_info );
         $this->assertArrayHasKey( 'normalized_name', $file_info );
-        
+
         $this->assertEquals( 'test_document.pdf', $file_info['filename'] );
         $this->assertStringContains( 'test_document.pdf', $file_info['path'] );
-        $this->assertGreaterThan( 0, $file_info['size'] );
+        $this->assertGreaterThan( 0, $file_info['size_bytes'] );
+        $this->assertGreaterThan( 0, $file_info['modified'] );
         $this->assertEquals( 'test-document', $file_info['normalized_name'] );
     }
 


### PR DESCRIPTION
## Summary
- restyle the folder file listing viewer with a dark theme and table layout for readability
- surface indexed file metadata including last modified timestamps and file sizes in kilobytes
- extend the scanner to capture modified time and file size for each indexed PDF

## Testing
- php -l src/Admin/AdminMenu.php
- php -l src/Services/FileScanner.php

------
https://chatgpt.com/codex/tasks/task_b_68f278df1ab4832ea495beb8f91f5aa2